### PR TITLE
Migrate to Java 21

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 21
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 21
     - name: Build with Maven
       run: mvn -B --file pom.xml -s $GITHUB_WORKSPACE/settings.xml clean verify -Pexample-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 21
           server-id: github
       - name: Configure Git user
         run: |

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@ Developers design a "API" for the department so these specialists can write func
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.46</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/core/src/main/java/com/jexunit/core/dataprovider/ExcelLoader.java
+++ b/core/src/main/java/com/jexunit/core/dataprovider/ExcelLoader.java
@@ -342,7 +342,7 @@ public class ExcelLoader {
                 } else {
                     final double number = cell.getNumericCellValue();
                     if ((number == Math.floor(number)) && !Double.isInfinite(number)) {
-                        return String.valueOf(new Double(number).intValue());
+                        return String.valueOf(Double.valueOf(number).intValue());
                     }
                     return String.valueOf(number);
                 }

--- a/core/src/test/java/com/jexunit/core/dataprovider/ExcelLoaderTest.java
+++ b/core/src/test/java/com/jexunit/core/dataprovider/ExcelLoaderTest.java
@@ -3,7 +3,7 @@ package com.jexunit.core.dataprovider;
 import com.jexunit.core.model.TestCase;
 import org.junit.Test;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -22,7 +22,7 @@ public class ExcelLoaderTest {
     @Test
     public void shouldReadExcel() throws Exception {
         final ExcelLoader target = new ExcelLoader();
-        final Map<String, List<TestCase<ExcelMetadata>>> data = target.readExcel(Paths.get("", "src", "test", "resources", "loader-test.xlsx").toAbsolutePath().toString());
+        final Map<String, List<TestCase<ExcelMetadata>>> data = target.readExcel(Path.of("", "src", "test", "resources", "loader-test.xlsx").toAbsolutePath().toString());
         assertEquals(1, data.size());
         final List<TestCase<ExcelMetadata>> testCases = data.get("worksheet1");
         assertNotNull(testCases);
@@ -34,7 +34,7 @@ public class ExcelLoaderTest {
     @Test
     public void shouldReadExcelTransposed() throws Exception {
         final ExcelLoader target = new ExcelLoader(false, true);
-        final Map<String, List<TestCase<ExcelMetadata>>> data = target.readExcel(Paths.get("", "src", "test", "resources", "loader-test-transpose.xlsx").toAbsolutePath().toString());
+        final Map<String, List<TestCase<ExcelMetadata>>> data = target.readExcel(Path.of("", "src", "test", "resources", "loader-test-transpose.xlsx").toAbsolutePath().toString());
         assertEquals(1, data.size());
         final List<TestCase<ExcelMetadata>> testCases = data.get("worksheet1");
         assertNotNull(testCases);

--- a/examples-complex/pom.xml
+++ b/examples-complex/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/examples-simple/pom.xml
+++ b/examples-simple/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.scm.id>github</project.scm.id>
     </properties>
 
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <!--<release>8</release>-->
                     <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
Resolves #3.

Migrates the build from Java 8 to Java 21, laddering through each LTS (8 → 11 → 17 → 21) via the OpenRewrite migration recipes:
- compiler `source`/`target` 8 → 21 (all modules); JDK 8 → 21 in the CI workflows
- Lombok 1.18.46 and maven-compiler-plugin 3.15.0 (Java-21 compatible)
- modernizes the removed `new Double(...)` constructor to `Double.valueOf(...)`

Verified locally: `mvn test` is green under Temurin 21 — all 12 previously-passing tests still pass (no test lost).

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.*
